### PR TITLE
Add support for custom auth backends

### DIFF
--- a/radiusauth/__init__.py
+++ b/radiusauth/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '1.0.0'
+VERSION = '1.1.0'

--- a/radiusauth/backends/radius.py
+++ b/radiusauth/backends/radius.py
@@ -6,7 +6,9 @@ from pyrad.client import Client, Timeout
 from pyrad.dictionary import Dictionary
 
 from django.conf import settings
-from django.contrib.auth.models import User
+#Handle custom user models
+from django.contrib.auth import get_user_model
+User = get_user_model()
 
 DICTIONARY = u"""
 ATTRIBUTE   User-Name       1   string


### PR DESCRIPTION
Newer version fo Django (1.5+) provide support for overriding the System auth backend; which means that modules that interact with it should, rather than directly referencing `django.contrib.auth.models.User`, get the correct user model using the appropriate methods.

This patch does that.